### PR TITLE
Fix a typo and add c around xinclude.

### DIFF
--- a/author-workflow.xml
+++ b/author-workflow.xml
@@ -27,8 +27,8 @@
             </p>
 
             <p>
-              WHen this section gets too big,
-              we can split it off as a separate file and xinclude it.
+              When this section gets too big,
+              we can split it off as a separate file and <c>xinclude</c> it.
             </p>
 
             <exercise>


### PR DESCRIPTION
I found a typo and thought it would be good to put c tags around xinclude.